### PR TITLE
Set charset to utf-8 in report

### DIFF
--- a/src/nl/jomco/apie/report.clj
+++ b/src/nl/jomco/apie/report.clj
@@ -385,7 +385,8 @@
   [openapi interactions base-url]
   (hiccup.page/html5
    [:html
-    [:head [:title (report-title base-url)]
+    [:head [:title (report-title base-url)
+           [:meta {:charset "UTF-8"}]]
      [:style (-> css-resource (io/resource) (slurp) (raw-css))]]
     [:body
      [:header


### PR DESCRIPTION
Safari doesn't default to utf-8 without this, showing the checkmark and smiley emojis as gibberish.
