### PR TITLE
Support JSON media subtype

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## NEXTVERSION
+ - Parse JSON bodies when mime subtype is "json"
 
 ## 0.2.2
  - Report text and layout improvements


### PR DESCRIPTION
The ooapi spec uses "application/problem+json" for error responses. This is a valid use of a media subtype, see https://www.rfc-editor.org/rfc/rfc6839#section-3.1

This patch ensures we attempt to parse and validate the response body when a json subtype is specified.