### PR TITLE
Handle IOException

### DIFF
--- a/src/nl/jomco/apie/report.clj
+++ b/src/nl/jomco/apie/report.clj
@@ -477,6 +477,10 @@
            (into [:dl])))
     [:dl [:dt "Collection is empty!"]]))
 
+(defmethod issue-details "network-error"
+  [_ _]
+  nil)
+
 ;; this also works for non-json-schema issue types
 (defmethod issue-details :default
   [openapi {:keys [instance path schema-path] :as issue}]
@@ -526,6 +530,11 @@
    (path-summary path) " expected one of: "
    (list-summary (:ranges hints))
    ", got " [:code instance]])
+
+(defmethod issue-summary "network-error"
+  [_ {:keys [hints instance path]}]
+  [:span
+   (str "Network error: " (:message hints))])
 
 (defmethod issue-summary :default
   [_ {:keys [issue]}]


### PR DESCRIPTION
If an IOException occurs while spidering, set http status to 0 and add the error message to the body.
In the report, render responses with status 0 as a network-error.
Define network-errors methods for issue-summary and issue-details.
